### PR TITLE
Add support for multiple smtp connections

### DIFF
--- a/django_pony_express/services/base.py
+++ b/django_pony_express/services/base.py
@@ -122,6 +122,7 @@ class BaseEmailService:
     cc_email_list = []
     bcc_email_list = []
     attachment_list = []
+    connection = None
 
     def __init__(
         self,
@@ -264,6 +265,7 @@ class BaseEmailService:
             bcc=self.get_bcc_emails(),
             reply_to=self.get_reply_to_emails(),
             to=self.recipient_email_list,
+            connection=self.connection,
         )
         msg.attach_alternative(html_content, "text/html")
 


### PR DESCRIPTION
1. Add 'connection' variable to BaseEmailService class
2. edit _build_mail_object function: add 'connection' variable to msg = EmailMultiAlternatives(...., connection=connection)

result: You can use own smtp connection with django.core.mail.get_connection() function for own BaseEmailService subclass.